### PR TITLE
[Feat] 약속방 나가기 API 구현, TimeSlot Toggle API 두개로 분리

### DIFF
--- a/src/main/java/org/example/whenwillwemeet/controller/AppointmentController.java
+++ b/src/main/java/org/example/whenwillwemeet/controller/AppointmentController.java
@@ -65,4 +65,11 @@ public class AppointmentController {
         CommonResponse response = appointmentService.createAppointment(appointmentCreateDto, loginUserId);
         return ResponseEntity.status(response.getStatus()).body(response);
     }
+
+    @DeleteMapping("/{appointmentId}")
+    public ResponseEntity<CommonResponse> exitAppointment(@PathVariable UUID appointmentId,
+        @LoginUserId UUID loginUserId) {
+        CommonResponse response = appointmentService.exitAppointment(appointmentId, loginUserId);
+        return ResponseEntity.status(response.getStatus()).body(response);
+    }
 }

--- a/src/main/java/org/example/whenwillwemeet/controller/AppointmentScheduleController.java
+++ b/src/main/java/org/example/whenwillwemeet/controller/AppointmentScheduleController.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.example.whenwillwemeet.common.CommonResponse;
 import org.example.whenwillwemeet.common.aop.annotation.LoginUserId;
 import org.example.whenwillwemeet.data.dto.ScheduleUpdateDto;
+import org.example.whenwillwemeet.data.dto.TimeslotToggleDto;
 import org.example.whenwillwemeet.service.ScheduleService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,6 +26,7 @@ public class AppointmentScheduleController {
     return ResponseEntity.status(response.getStatus()).body(response);
   }
 
+  @Deprecated
   @PatchMapping("")
   public ResponseEntity<CommonResponse> updateUserTimeSlots(
       @PathVariable UUID appointmentId,
@@ -33,6 +35,24 @@ public class AppointmentScheduleController {
   ) {
     CommonResponse response = scheduleService.updateUserTimeSlots(appointmentId, schedule,
         loginUserId);
+    return ResponseEntity.status(response.getStatus()).body(response);
+  }
+
+  @PatchMapping("/{scheduleId}/timeslots/toggle")
+  public ResponseEntity<CommonResponse> updateTimeSlots(
+      @PathVariable UUID appointmentId,
+      @PathVariable Long scheduleId,
+      @Valid @RequestBody TimeslotToggleDto dto,
+      @LoginUserId UUID loginUserId
+  ) {
+    CommonResponse response;
+    if (dto.isEnabled()) {
+      response = scheduleService.enableTimeslot(appointmentId, scheduleId, dto, loginUserId);
+    }
+    else {
+      response = scheduleService.disabledTimeslot(appointmentId, scheduleId, dto, loginUserId);
+    }
+
     return ResponseEntity.status(response.getStatus()).body(response);
   }
 

--- a/src/main/java/org/example/whenwillwemeet/data/dto/TimeslotToggleDto.java
+++ b/src/main/java/org/example/whenwillwemeet/data/dto/TimeslotToggleDto.java
@@ -1,0 +1,22 @@
+package org.example.whenwillwemeet.data.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TimeslotToggleDto {
+
+  @NotNull(message = "Enabled is required")
+  private boolean enabled;
+
+  @NotEmpty(message = "At least one time must be provided")
+  private List<@NotNull(message = "Time value cannot be null") LocalDateTime> times = new ArrayList<>();
+}

--- a/src/main/java/org/example/whenwillwemeet/repository/ScheduleRepository.java
+++ b/src/main/java/org/example/whenwillwemeet/repository/ScheduleRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.example.whenwillwemeet.domain.entity.Appointment;
 import org.example.whenwillwemeet.domain.entity.Schedule;
 import org.example.whenwillwemeet.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -33,4 +34,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
   List<Schedule> findWithTimeSlotByAppointmentIdAndUser(
       @Param("appointmentId") UUID appointmentId,
       @Param("user") User user);
+
+  List<Schedule> findByAppointment(Appointment appointment);
 }

--- a/src/main/java/org/example/whenwillwemeet/repository/TimeSlotRepository.java
+++ b/src/main/java/org/example/whenwillwemeet/repository/TimeSlotRepository.java
@@ -1,7 +1,13 @@
 package org.example.whenwillwemeet.repository;
 
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import org.example.whenwillwemeet.domain.entity.Schedule;
 import org.example.whenwillwemeet.domain.entity.TimeSlot;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TimeSlotRepository extends JpaRepository<TimeSlot, Long> {
+
+  List<TimeSlot> findByScheduleAndTimeIn(Schedule schedule, Collection<LocalDateTime> times);
 }

--- a/src/main/java/org/example/whenwillwemeet/repository/UserAppointmentRepository.java
+++ b/src/main/java/org/example/whenwillwemeet/repository/UserAppointmentRepository.java
@@ -1,6 +1,7 @@
 package org.example.whenwillwemeet.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.example.whenwillwemeet.domain.entity.Appointment;
 import org.example.whenwillwemeet.domain.entity.User;
 import org.example.whenwillwemeet.domain.entity.UserAppointment;
@@ -13,4 +14,8 @@ public interface UserAppointmentRepository extends JpaRepository<UserAppointment
 
   @EntityGraph(attributePaths = {"appointment"})
   List<UserAppointment> findByUser(User user);
+
+  void deleteByAppointmentAndUser(Appointment appointmentReference, User me);
+
+  int countByAppointment(Appointment appointmentRef);
 }

--- a/src/main/java/org/example/whenwillwemeet/repository/UserTimeSlotRepository.java
+++ b/src/main/java/org/example/whenwillwemeet/repository/UserTimeSlotRepository.java
@@ -1,7 +1,14 @@
 package org.example.whenwillwemeet.repository;
 
+
+import java.util.Collection;
+import java.util.List;
+import org.example.whenwillwemeet.domain.entity.TimeSlot;
+import org.example.whenwillwemeet.domain.entity.User;
 import org.example.whenwillwemeet.domain.entity.UserTimeSlot;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserTimeSlotRepository extends JpaRepository<UserTimeSlot, Long> {
+
+  List<UserTimeSlot> findByUserAndTimeSlotIn(User user, Collection<TimeSlot> timeSlots);
 }

--- a/src/main/java/org/example/whenwillwemeet/repository/UserTimeSlotRepository.java
+++ b/src/main/java/org/example/whenwillwemeet/repository/UserTimeSlotRepository.java
@@ -3,6 +3,7 @@ package org.example.whenwillwemeet.repository;
 
 import java.util.Collection;
 import java.util.List;
+import org.example.whenwillwemeet.domain.entity.Schedule;
 import org.example.whenwillwemeet.domain.entity.TimeSlot;
 import org.example.whenwillwemeet.domain.entity.User;
 import org.example.whenwillwemeet.domain.entity.UserTimeSlot;
@@ -10,5 +11,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserTimeSlotRepository extends JpaRepository<UserTimeSlot, Long> {
 
-  List<UserTimeSlot> findByUserAndTimeSlotIn(User user, Collection<TimeSlot> timeSlots);
+  void deleteByUserAndTimeSlot_ScheduleIn(User me, List<Schedule> schedules);
+
+  void deleteByUserAndTimeSlotIn(User loginUser, List<TimeSlot> targetTimeSlots);
 }

--- a/src/main/java/org/example/whenwillwemeet/service/ScheduleService.java
+++ b/src/main/java/org/example/whenwillwemeet/service/ScheduleService.java
@@ -99,10 +99,7 @@ public class ScheduleService {
     List<TimeSlot> targetTimeSlots = timeSlotRepository.findByScheduleAndTimeIn(schedule,
         dto.getTimes());
 
-    List<UserTimeSlot> byUserAndTimeSlotIn = userTimeSlotRepository.findByUserAndTimeSlotIn(
-        loginUser, targetTimeSlots);
-
-    userTimeSlotRepository.deleteAll(byUserAndTimeSlotIn);
+    userTimeSlotRepository.deleteByUserAndTimeSlotIn(loginUser, targetTimeSlots);
 
     return new CommonResponse(true, HttpStatus.OK,
         "Schedule [" + scheduleId + "], User [" + loginUser.getId()


### PR DESCRIPTION
## 요약 (Summary)

약속방 나가기 API 구현, TimeSlot Toggle API 두개로 분리

## 변경 사항 (Changes)

약속방 나가기 API 구현. (/api/v2/appointments/{appointmentId})
DB와 로컬 메모리 성능상의 이유로 TimeSlot Toggle API 를 활성화, 비활성화 로직으로 분리함.

## 리뷰 요구사항

## 확인 방법 (선택)
